### PR TITLE
feat: Add `serde` support behind a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,9 @@ authors = ["Chris Connelly <chris@connec.co.uk>"]
 description = "Check yourself before you wreck yourself."
 license = "MIT"
 repository = "https://github.com/connec/check_mate"
+
+[dependencies]
+serde = { version = "1", default-features = false, features = ["derive"], optional = true }
+
+[dev-dependencies]
+serde_json = { version = "1" }


### PR DESCRIPTION
This makes it possible to directly serialize `Checked<T>` values, which
will be transparently serialized as if it were just `T`. `Checked<T>`
values can also be deserialized, but only if `T`'s `Check` impl returns
itself as the OK variant (otherwise, we would not know what to
deserialize first).